### PR TITLE
Use a descriptive backport title

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "p-series": "^2.0.0",
     "probot-serverless-now": "^1.0.1",
     "debug": "^4.1.1",
-    "github-backport": "^1.0.1",
+    "github-backport": "^1.1.0",
     "shared-github-internals": "^1.0.0"
   },
   "description": "GitHub App to backport pull requests",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1697,10 +1697,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github-backport@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/github-backport/-/github-backport-1.0.1.tgz#662a92e4e7731181b345009883c2a3df0258a837"
-  integrity sha512-8x8L49mmrxYhE0TLaMptxj5iugf21Mba8DrNb54+aNI1mk8CYFNSCznYZSchS+O2puCfIpDfMyVAfwklhCfPZA==
+github-backport@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/github-backport/-/github-backport-1.1.0.tgz#d569557653bf18e113a02ee99c5b43a0bdfc187d"
+  integrity sha512-QqMpTQHAUxbKiVlQN1PBNIqcAf59eYxXHO83nHr3W0KsMQv5aT2y3Z7WNqY/Rwr8y+fbLYIF6kj1uA2F341CbQ==
   dependencies:
     "@octokit/rest" "^16.8.0"
     "@types/debug" "^0.0.31"


### PR DESCRIPTION
It's hard to know which branch has been backported by the number only.

Right now, the information is two clicks away (click on pull request to open it, click on the link to the original pull request).

I'm totally new to TypeScript and github api. Please review thoroughly.