### PR TITLE
Add add_labels feature

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   github_token:
     description: Token for the GitHub API.
     required: true
+  add_labels:
+    description: A comma separated list of labels to add to the backport PR.
+    required: false
 runs:
   using: node12
   main: dist/index.js

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -75,6 +75,7 @@ const backportOnce = async ({
   commitToBackport,
   github,
   head,
+  labelsToAdd,
   owner,
   repo,
   title,
@@ -84,6 +85,7 @@ const backportOnce = async ({
   commitToBackport: string;
   github: GitHub;
   head: string;
+  labelsToAdd: string[];
   owner: string;
   repo: string;
   title: string;
@@ -102,13 +104,19 @@ const backportOnce = async ({
   }
 
   await git("push", "--set-upstream", "origin", head);
-  await github.pulls.create({
+  const { data: pr } = await github.pulls.create({
     base,
     body,
     head,
     owner,
     repo,
     title,
+  });
+  await github.issues.addLabels({
+    issue_number: pr.number,
+    labels: labelsToAdd,
+    owner,
+    repo,
   });
 };
 
@@ -153,6 +161,7 @@ const getFailedBackportCommentBody = ({
 };
 
 const backport = async ({
+  labelsToAdd,
   payload: {
     action,
     // The payload has a label property when the action is "labeled".
@@ -172,6 +181,7 @@ const backport = async ({
   },
   token,
 }: {
+  labelsToAdd: string[];
   payload: WebhookPayloadPullRequest;
   token: string;
 }) => {
@@ -221,6 +231,7 @@ const backport = async ({
           commitToBackport,
           github,
           head,
+          labelsToAdd,
           owner,
           repo,
           title,

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -104,7 +104,9 @@ const backportOnce = async ({
   }
 
   await git("push", "--set-upstream", "origin", head);
-  const { data: pr } = await github.pulls.create({
+  const {
+    data: { number: pullRequestNumber },
+  } = await github.pulls.create({
     base,
     body,
     head,
@@ -112,12 +114,14 @@ const backportOnce = async ({
     repo,
     title,
   });
-  await github.issues.addLabels({
-    issue_number: pr.number,
-    labels: labelsToAdd,
-    owner,
-    repo,
-  });
+  if (labelsToAdd.length > 0) {
+    await github.issues.addLabels({
+      issue_number: pullRequestNumber,
+      labels: labelsToAdd,
+      owner,
+      repo,
+    });
+  }
 };
 
 const getFailedBackportCommentBody = ({

--- a/src/get-labels-to-add.ts
+++ b/src/get-labels-to-add.ts
@@ -1,0 +1,12 @@
+/**
+ * Get an array of labels to be added to the PR.
+ * Filtering out empty strings.
+ */
+export const getLabelsToAdd = (input: string | undefined): string[] => {
+  if (input === undefined || input === "") {
+    return [];
+  }
+
+  const labels = input.split(",");
+  return labels.map(v => v.trim()).filter(v => v !== "");
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,16 @@ import { context } from "@actions/github";
 import { WebhookPayloadPullRequest } from "@octokit/webhooks";
 
 import { backport } from "./backport";
+import { getLabelsToAdd } from "./get-labels-to-add";
 
 const run = async () => {
   try {
     const token = getInput("github_token", { required: true });
     debug(JSON.stringify(context, null, 2));
+    const labelsInput = getInput("labels");
+    const labelsToAdd = getLabelsToAdd(labelsInput);
     await backport({
+      labelsToAdd,
       payload: context.payload as WebhookPayloadPullRequest,
       token,
     });


### PR DESCRIPTION
Some users may want to have labels added to backport PRs. e.g. a general "this is a backport PR label", which could be just "backport". Alternatively they may want a label like "autosquash".

Not sure if this works yet. Just adding for feedback.