### PR TITLE
add message template

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,18 @@ inputs:
     description: Template for the title of the backport PR.
     required: false
     default: "[Backport {{base}}] {{originalTitle}}"
+  message_template:
+    description: |
+      Template for the message of the backport pull request.
+      Supported directives are:
+        - {{base}}: the base branch to which the PR is backported.
+        - {{originalTitle}}: the title of the original pull request
+        - {{originalMessage}}: the commit message of the original pull request
+          merge commit without the first line.
+        - {{pullRequestNumber}}: the original pull request number.
+        - {{commitToBackport}}: the SHA of the original pull request merge commit.
+    required: false
+    default: "Backport {{commitToBackport}} from #{{pullRequestNumber}}"
 runs:
   using: node12
   main: dist/index.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,14 @@ import { getLabelsToAdd } from "./get-labels-to-add";
 const run = async () => {
   try {
     const token = getInput("github_token", { required: true });
+    const messageTemplate = getInput("message_template");
     const titleTemplate = getInput("title_template");
     debug(JSON.stringify(context, undefined, 2));
     const labelsInput = getInput("labels");
     const labelsToAdd = getLabelsToAdd(labelsInput);
     await backport({
       labelsToAdd,
+      messageTemplate,
       payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
       titleTemplate,
       token,


### PR DESCRIPTION
Add a message template that configures the message body of the backport
pull request.

The template allows for the following directives:

    - {{base}}: the base branch to which the PR is backported.
    - {{originalTitle}}: the title of the original pull request
    - {{originalMessage}}: the commit message of the original pull request
      merge commit without the first line.
    - {{pullRequestNumber}}: the original pull request number.
    - {{commitToBackport}}: the SHA of the original pull request merge commit.

The default template is consistent with previous behavior:

    "Backport {{commitToBackport}} from #{{pullRequestNumber}}"

fixes #53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tibdex/backport/54)
<!-- Reviewable:end -->
