### PR TITLE
Allow backporting "merge" commits

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -107,7 +107,7 @@ const backportOnce = async ({
   await git("switch", base);
   await git("switch", "--create", head);
   try {
-    await git("cherry-pick", commitToBackport);
+    await git("cherry-pick", "--mainline", "1", commitToBackport);
   } catch (error: unknown) {
     await git("cherry-pick", "--abort");
     throw error;


### PR DESCRIPTION
Applies the suggestion from https://github.com/tibdex/backport/issues/43 to automated backport process.

There are 3 possibilities to merge PRs on github

 - squash and merge --> currently works
 - rebase --> works if it's a single commit, otherwise attempts to backport last commit
 - create merge commit  --> currently not working, fixed by this patch