### PR TITLE
When running `git cherry-pick`, pass the `-x` flag to make sure that the "cherry picked from commit ..." line is appended to the end of the commit message

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -107,7 +107,7 @@ const backportOnce = async ({
   await git("switch", base);
   await git("switch", "--create", head);
   try {
-    await git("cherry-pick", commitToBackport);
+    await git("cherry-pick", "-x", commitToBackport);
   } catch (error: unknown) {
     await git("cherry-pick", "--abort");
     throw error;
@@ -162,7 +162,7 @@ const getFailedBackportCommentBody = ({
     "# Create a new branch",
     `git switch --create ${head}`,
     "# Cherry-pick the merged commit of this pull request and resolve the conflicts",
-    `git cherry-pick --mainline 1 ${commitToBackport}`,
+    `git cherry-pick -x --mainline 1 ${commitToBackport}`,
     "# Push it to GitHub",
     `git push --set-upstream origin ${head}`,
     "# Go back to the original working tree",


### PR DESCRIPTION
This PR passes the `-x` flag when running `git cherry-pick`. This causes the "cherry picked from commit ..." line to be appended to the end of the commit message.

Personally, I think it would be fine for this to be the default behavior. However, @tibdex if you would prefer to make this opt-in, we can add a new input that allows the user to opt-in to this behavior.