### PR TITLE
Recommend using the `pull_request_target` trigger (instead of the `pull_request` trigger) so that PRs from forks can be backported

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,6 +9,7 @@ jobs:
   backport:
     runs-on: ubuntu-18.04
     name: Backport
+    if: github.event.pull_request.merged
     steps:
       - name: Backport
         uses: tibdex/backport@v1


### PR DESCRIPTION
Fixes #33

If a pull request is made from a fork, jobs triggered by the `pull_request` trigger will not have access to a `GITHUB_TOKEN` that has write access. In contrast, jobs triggered by the `pull_request_target` trigger will always have access to a `GITHUB_TOKEN` that has write access, even if the pull request is made from a fork. Therefore, if we recommend that users use the `pull_request_target` trigger, then they should be able to use this action on pull requests made from forks.

---

## Security

Because  jobs triggered by the `pull_request_target` trigger will always have access to a `GITHUB_TOKEN` that has write access (even if the pull request is made from a fork), GitHub publishes the following security advice ([source][1]):

> Warning: The pull_request_target event is granted a read/write repository token and can access secrets, even when it is triggered from a fork. Although the workflow runs in the context of the base of the pull request, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. Additionally, any caches share the same scope as the base branch, and to help prevent cache poisoning, you should not save the cache if there is a possibility that the cache contents were altered. For more information, see "[Keeping your GitHub Actions and workflows secure: Preventing pwn requests][2]" on the GitHub Security Lab website.

@tibdex Does this action do any of the following on a pull request that has not been merged?
1. Check out code
2. Build code
3. Run code

If this action does any of the above on a pull request that has not been merged, then we should not use the `pull_request_target` trigger, because that would be a security risk.

However, if this action only does those things (check out, build, run) on pull requests that have been merged, then as far as I can tell, there is no security concern.

[1]: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target
[2]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/