### PR TITLE
Change `if (!merged)` to `if (merged !== true)`

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -199,7 +199,7 @@ const backport = async ({
   titleTemplate: string;
   token: string;
 }) => {
-  if (!merged) {
+  if (merged !== true) {
     return;
   }
 


### PR DESCRIPTION
This makes sure to cover the edge case in which `merged` is not a `boolean`.