### PR TITLE
copy labels from original PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Template for the title of the backport PR.
     required: false
     default: "[Backport {{base}}] {{originalTitle}}"
+  copy_original_labels:
+    description: Copy labels (minus the backport label) to the backport PR
+    required: false
+    default: ""
 runs:
   using: node12
   main: dist/index.js

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -174,7 +174,18 @@ const getFailedBackportCommentBody = ({
   ].join("\n");
 };
 
+const getOriginalLabels = (
+  labels: EventPayloads.WebhookPayloadPullRequestLabel[],
+): string[] => {
+  const filteredLables = labels.filter(
+    (label) => !labelRegExp.exec(label.name),
+  );
+
+  return filteredLables.map((label) => label.name);
+};
+
 const backport = async ({
+  copyOriginalLabels,
   labelsToAdd,
   payload: {
     action,
@@ -194,6 +205,7 @@ const backport = async ({
   titleTemplate,
   token,
 }: {
+  copyOriginalLabels: boolean;
   labelsToAdd: string[];
   payload: EventPayloads.WebhookPayloadPullRequest;
   titleTemplate: string;
@@ -213,6 +225,10 @@ const backport = async ({
 
   if (Object.keys(backportBaseToHead).length === 0) {
     return;
+  }
+
+  if (copyOriginalLabels) {
+    labelsToAdd = labelsToAdd.concat(getOriginalLabels(labels));
   }
 
   const github = getOctokit(token);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,9 @@ const run = async () => {
     debug(JSON.stringify(context, undefined, 2));
     const labelsInput = getInput("add_labels");
     const labelsToAdd = getLabelsToAdd(labelsInput);
+    const copyOriginalLabels = getInput("copy_original_labels") !== "";
     await backport({
+      copyOriginalLabels,
       labelsToAdd,
       payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
       titleTemplate,


### PR DESCRIPTION
Currently, if users rely on labels to build changelogs or other reporting features, backport PRs must be manually re-labeled with the original labels.  

This PR adds a new optional flag - `copy_original_labels`.  If this flag is set, the backport action copies the original labels to the new PR, stripping anything that matches the backport trigger label regex.  This can save a lot of manual and error prone toil for teams that rely heavily on labels for other automation.

Closes https://github.com/tibdex/backport/issues/64
