### PR TITLE
Adding an option for custom branch name for backport

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   add_labels:
     description: Comma separated list of labels to add to the backport PR.
     required: false
+  branch_name:
+    description: Custom branch name for the backport PR.
+    required: false
   github_token:
     description: Token for the GitHub API.
     required: true

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -28,16 +28,16 @@ const getLabelNames = ({
 
 const getBackportBaseToHead = ({
   action,
+  branchName,
   label,
   labels,
   pullRequestNumber,
-  branchName,
 }: {
   action: EventPayloads.WebhookPayloadPullRequest["action"];
+  branchName: string;
   label: { name: string };
   labels: EventPayloads.WebhookPayloadPullRequest["pull_request"]["labels"];
   pullRequestNumber: number;
-  branchName: string;
 }): Record<string, string> => {
   const baseToHead: Record<string, string> = {};
 
@@ -48,7 +48,7 @@ const getBackportBaseToHead = ({
       const [
         ,
         base,
-        head = (branchName != null) ? `${branchName}-to-${base}` : `backport-${pullRequestNumber}-to-${base}`,
+        head = (branchName !== null) ? `${branchName}-to-${base}` : `backport-${pullRequestNumber}-to-${base}`,
       ] = matches;
       baseToHead[base] = head;
     }
@@ -177,6 +177,7 @@ const getFailedBackportCommentBody = ({
 };
 
 const backport = async ({
+  branchName,
   labelsToAdd,
   payload: {
     action,
@@ -195,13 +196,12 @@ const backport = async ({
   },
   titleTemplate,
   token,
-  branchName,
 }: {
+  branchName: string;
   labelsToAdd: string[];
   payload: EventPayloads.WebhookPayloadPullRequest;
   titleTemplate: string;
   token: string;
-  branchName: string;
 }) => {
   if (merged !== true) {
     return;
@@ -209,11 +209,11 @@ const backport = async ({
 
   const backportBaseToHead = getBackportBaseToHead({
     action,
+    branchName,
     // The payload has a label property when the action is "labeled".
     label: label!,
     labels,
     pullRequestNumber,
-    branchName,
   });
 
   if (Object.keys(backportBaseToHead).length === 0) {

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -31,11 +31,13 @@ const getBackportBaseToHead = ({
   label,
   labels,
   pullRequestNumber,
+  branchName,
 }: {
   action: EventPayloads.WebhookPayloadPullRequest["action"];
   label: { name: string };
   labels: EventPayloads.WebhookPayloadPullRequest["pull_request"]["labels"];
   pullRequestNumber: number;
+  branchName: string;
 }): Record<string, string> => {
   const baseToHead: Record<string, string> = {};
 
@@ -46,7 +48,7 @@ const getBackportBaseToHead = ({
       const [
         ,
         base,
-        head = `backport-${pullRequestNumber}-to-${base}`,
+        head = (branchName != null) ? `${branchName}-to-${base}` : `backport-${pullRequestNumber}-to-${base}`,
       ] = matches;
       baseToHead[base] = head;
     }
@@ -193,11 +195,13 @@ const backport = async ({
   },
   titleTemplate,
   token,
+  branchName,
 }: {
   labelsToAdd: string[];
   payload: EventPayloads.WebhookPayloadPullRequest;
   titleTemplate: string;
   token: string;
+  branchName: string;
 }) => {
   if (merged !== true) {
     return;
@@ -209,6 +213,7 @@ const backport = async ({
     label: label!,
     labels,
     pullRequestNumber,
+    branchName,
   });
 
   if (Object.keys(backportBaseToHead).length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ const run = async () => {
   try {
     const token = getInput("github_token", { required: true });
     const titleTemplate = getInput("title_template");
+    const branchName = getInput("branch_name");
     debug(JSON.stringify(context, undefined, 2));
     const labelsInput = getInput("add_labels");
     const labelsToAdd = getLabelsToAdd(labelsInput);
@@ -17,6 +18,7 @@ const run = async () => {
       payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
       titleTemplate,
       token,
+      branchName,
     });
   } catch (error: unknown) {
     if (typeof error !== "string" && !(error instanceof Error)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,11 @@ const run = async () => {
     const labelsInput = getInput("add_labels");
     const labelsToAdd = getLabelsToAdd(labelsInput);
     await backport({
+      branchName,
       labelsToAdd,
       payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
       titleTemplate,
       token,
-      branchName,
     });
   } catch (error: unknown) {
     if (typeof error !== "string" && !(error instanceof Error)) {


### PR DESCRIPTION
Implemented #80.

Allows an option to configure the branch name while creating backport PRs.