### PR TITLE
feat: Reuse PR Body from Original PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It thus integrates well with [Autosquash](https://github.com/marketplace/actions
 1.  :electric_plug: Add this [.github/workflows/backport.yml](.github/workflows/backport.yml) to your repository.
 
 2.  :speech_balloon: Let's say you want to backport a pull request on a branch named `production`.
-    
+
     Then label it with `backport production`. (See [how to create labels](https://help.github.com/articles/creating-a-label/).)
 
 3.  :sparkles: That's it! When the pull request gets merged, it will be backported to the `production` branch.
@@ -16,3 +16,13 @@ It thus integrates well with [Autosquash](https://github.com/marketplace/actions
 
 _Note:_ multiple backport labels can be added.
 For example, if a pull request has the labels `backport staging` and `backport production` it will be backported to both branches: `staging` and `production`.
+
+## Inputs
+
+- `github_token`: `string`- **required**
+
+- `title_template`: `string` - A custom title tempalte that will be used as the title for the Backport pull request
+
+- `reuse_pr_body`: `bool` - Allows Backport to copy the original pull request body contents and use them in the Backport pull request
+
+- `add_labels`: `string[]` - String array of `labels` to be added to the Backport pull request (e.g. `reviewed,ready-for-release,etc.` -> All of these will be added as labels to the new PR)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,14 @@ const run = async () => {
   try {
     const token = getInput("github_token", { required: true });
     const titleTemplate = getInput("title_template");
-    debug(JSON.stringify(context, undefined, 2));
+    const reusePRBody = getInput("reuse_pr_body");
+
     const labelsInput = getInput("add_labels");
     const labelsToAdd = getLabelsToAdd(labelsInput);
     await backport({
       labelsToAdd,
       payload: context.payload as EventPayloads.WebhookPayloadPullRequest,
+      reusePRBody: Boolean(reusePRBody),
       titleTemplate,
       token,
     });


### PR DESCRIPTION
Hey there @tibdex! 

I'm raising this PR to add the functionality of reusing the original PR description (while appending the existing backport body). 

We utilize the Pull Request body in our repo to be able to tie our issue tracker to our release tooling. This helps us assure we have all of the right information prior to releasing. 

I added the option as a `boolean` check via `input`. So if a user sets the configuration to `reuse_pr_body` then the original PR body will be copied over with the new backport PR. 

Let me know what you think - and if there are any changes you'd like made. 