### PR TITLE
feat: use clone url provided from the payload to support GHES

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -251,10 +251,11 @@ const backport = async ({
 
   info(`Backporting ${mergeCommitSha} from #${number}.`);
 
-  await exec("git", [
-    "clone",
-    `https://x-access-token:${token}@github.com/${owner}/${repo}.git`,
-  ]);
+  const cloneUrl = new URL(payload.repository.clone_url);
+  cloneUrl.username = "x-access-token";
+  cloneUrl.password = token;
+
+  await exec("git", ["clone", cloneUrl.toString()]);
   await exec("git", [
     "config",
     "--global",


### PR DESCRIPTION
~~Created this PR as a draft, to test it in some of our internal GitHub Enterprise Server projects, but I guess the change is fine and can already be reviewed :)~~