### PR TITLE
Provide original PR's title in `body_template`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
 
       The data properties are:
         - base: backport PR's base branch
+        - title: original PR's title
         - body: original PR's body
         - mergeCommitSha: SHA of the original PR's merge commit
         - number: original PR's number

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -189,6 +189,7 @@ const backport = async ({
   getBody: (
     props: Readonly<{
       base: string;
+      title: string;
       body: string;
       mergeCommitSha: string;
       number: number;
@@ -270,6 +271,7 @@ const backport = async ({
   for (const base of baseBranches) {
     const body = getBody({
       base,
+      title: originalTitle,
       body: originalBody ?? "",
       mergeCommitSha,
       number,


### PR DESCRIPTION
This allows me to use the title in the backport PR body, for example, to better integrate with release-please:
```
Backport <%= mergeCommitSha %> from #<%= number %>.

BEGIN_COMMIT_OVERRIDE
<%= title %>
END_COMMIT_OVERRIDE
```

https://github.com/googleapis/release-please#how-can-i-fix-release-notes